### PR TITLE
fix: Upload progress `contentLength`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 2025-08-01
+
+- Fix progress notification for `uploadFile`.
+- Fix error (only visible in logs) related to `chunkedMode` and `httpBodyStream`.
+
 ## 1.0.0
 
 ### 2025-04-14

--- a/IONFileTransferLib/Delegates/IONFLTRUploadDelegate.swift
+++ b/IONFileTransferLib/Delegates/IONFLTRUploadDelegate.swift
@@ -8,6 +8,9 @@ import Foundation
 /// - Note: This class conforms to `URLSessionTaskDelegate` and `URLSessionDataDelegate` to handle task-specific events.
 class IONFLTRUploadDelegate: IONFLTRBaseDelegate {
 
+    /// the URL pointing to the file to upload
+    let fileURL: URL
+    
     /// The total number of bytes sent during the upload.
     private var totalBytesSent: Int = 0
     
@@ -20,7 +23,9 @@ class IONFLTRUploadDelegate: IONFLTRBaseDelegate {
     /// - Parameters:
     ///   - publisher: The publisher used to send progress and success updates.
     ///   - disableRedirects: A flag indicating whether HTTP redirects should be disabled.
-    override init(publisher: IONFLTRPublisher, disableRedirects: Bool) {
+    ///   - fileURL: the URL pointing to the file to upload
+    init(publisher: IONFLTRPublisher, disableRedirects: Bool, fileURL: URL) {
+        self.fileURL = fileURL
         super.init(publisher: publisher, disableRedirects: disableRedirects)
     }
 }
@@ -99,5 +104,16 @@ extension IONFLTRUploadDelegate: URLSessionDataDelegate {
     ///   - data: The data received from the server.
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         receivedData.append(data)
+    }
+    
+    /// Handles sending a body stream of the file to upload. Relevant for chunkedMode=true
+    ///
+    /// - Parameters:
+    ///   - session: The `URLSession` containing the data task.
+    ///   - task: The `URLSessionTask` that wiill get the input stream
+    func urlSession(_ session: URLSession, needNewBodyStreamForTask task: URLSessionTask) async -> InputStream? {
+        print("needNewBodyStream")
+        let stream = InputStream(fileAtPath: fileURL.path)
+        return stream
     }
 }

--- a/IONFileTransferLib/Delegates/IONFLTRUploadDelegate.swift
+++ b/IONFileTransferLib/Delegates/IONFLTRUploadDelegate.swift
@@ -111,9 +111,9 @@ extension IONFLTRUploadDelegate: URLSessionDataDelegate {
     /// - Parameters:
     ///   - session: The `URLSession` containing the data task.
     ///   - task: The `URLSessionTask` that wiill get the input stream
-    func urlSession(_ session: URLSession, needNewBodyStreamForTask task: URLSessionTask) async -> InputStream? {
+    func urlSession(_ session: URLSession, task: URLSessionTask, needNewBodyStream completionHandler: @escaping (InputStream?) -> Void) {
         print("needNewBodyStream")
         let stream = InputStream(fileAtPath: fileURL.path)
-        return stream
+        completionHandler(stream)
     }
 }

--- a/IONFileTransferLib/Helpers/IONFLTRURLRequestHelper.swift
+++ b/IONFileTransferLib/Helpers/IONFLTRURLRequestHelper.swift
@@ -77,8 +77,6 @@ class IONFLTRURLRequestHelper {
         let fileLength = getFileSize(from: fileURL)
 
         if uploadOptions.chunkedMode {
-            let inputStream = InputStream(fileAtPath: fileURL.path)
-            request.httpBodyStream = inputStream
             request.setContentLengthHeader(httpOptions: httpOptions, contentLength: fileLength)
             return (request, fileURL)
         } else if isMultipartUpload {

--- a/IONFileTransferLib/Helpers/IONFLTRURLRequestHelper.swift
+++ b/IONFileTransferLib/Helpers/IONFLTRURLRequestHelper.swift
@@ -73,18 +73,23 @@ class IONFLTRURLRequestHelper {
                 request.setValue(mimeType, forHTTPHeaderField: "Content-Type")
             }
         }
+        
+        let fileLength = getFileSize(from: fileURL)
 
         if uploadOptions.chunkedMode {
             let inputStream = InputStream(fileAtPath: fileURL.path)
             request.httpBodyStream = inputStream
+            request.setContentLengthHeader(httpOptions: httpOptions, contentLength: fileLength)
             return (request, fileURL)
         } else if isMultipartUpload {
             let httpBody = try createMultipartBody(uploadOptions: uploadOptions, fileURL: fileURL, fileHelper: fileHelper, boundary: boundary)
             let tempFileURL = FileManager.default.temporaryDirectory.appendingPathComponent("multipart_\(UUID().uuidString).tmp")
+            request.setContentLengthHeader(httpOptions: httpOptions, contentLength: Int64(httpBody.count))
             try httpBody.write(to: tempFileURL)
             return (request, tempFileURL)
         }
 
+        request.setContentLengthHeader(httpOptions: httpOptions, contentLength: fileLength)
         return (request, fileURL)
     }
 
@@ -160,6 +165,25 @@ class IONFLTRURLRequestHelper {
 
         body.append("--\(boundary)--\(lineEnd)".data(using: .utf8)!)
         return body
+    }
+    
+    private func getFileSize(from url: URL) -> Int64 {
+        do {
+            return try FileManager.default.attributesOfItem(atPath: url.path)[.size] as! Int64
+        } catch {
+            return 0
+        }
+    }
+}
+
+private extension URLRequest {
+    mutating func setContentLengthHeader(
+        httpOptions: IONFLTRHttpOptions,
+        contentLength: Int64
+    ) {
+        if (!httpOptions.headers.keys.contains("Content-Length") && contentLength > 0) {
+            setValue(String(contentLength), forHTTPHeaderField: "Content-Length")
+        }
     }
 }
 

--- a/IONFileTransferLib/IONFLTRManager.swift
+++ b/IONFileTransferLib/IONFLTRManager.swift
@@ -87,7 +87,8 @@ public class IONFLTRManager: NSObject {
             let publisher = IONFLTRPublisher()
             let delegate = IONFLTRUploadDelegate(
                 publisher: publisher,
-                disableRedirects: httpOptions.disableRedirects
+                disableRedirects: httpOptions.disableRedirects,
+                fileURL: fileURL
             )
             let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
             if uploadOptions.chunkedMode {

--- a/IONFileTransferLibTests/Helpers/IONFLTRURLRequestHelperTests.swift
+++ b/IONFileTransferLibTests/Helpers/IONFLTRURLRequestHelperTests.swift
@@ -134,20 +134,10 @@ class IONFLTRURLRequestHelperTests: XCTestCase {
             fileHelper: fileHelper
         )
         
-        let stream = configuredRequest.httpBodyStream
-        stream?.open()
-        let bufferSize = 1024
-        var buffer = [UInt8](repeating: 0, count: bufferSize)
-        var data = Data()
-        while let bytesRead = stream?.read(&buffer, maxLength: bufferSize), bytesRead > 0 {
-            data.append(buffer, count: bytesRead)
-        }
-        stream?.close()
-
         let fileData = try Data(contentsOf: testFileURL)
-
-        XCTAssertEqual(data, fileData)
         XCTAssertEqual(fileURL, testFileURL)
+        XCTAssertNil(configuredRequest.httpBodyStream)
+        XCTAssertEqual(configuredRequest.value(forHTTPHeaderField: "Content-Length"), String(fileData.count))
     }
     
     func testConfigureRequestForUpload_withMultipartUpload() throws {
@@ -169,7 +159,9 @@ class IONFLTRURLRequestHelperTests: XCTestCase {
             fileHelper: fileHelper
         )
 
+        let fileData = try Data(contentsOf: testFileURL)
         XCTAssertEqual(configuredRequest.value(forHTTPHeaderField: "Content-Type")?.contains("multipart/form-data"), true)
+        XCTAssertTrue(Int(configuredRequest.value(forHTTPHeaderField: "Content-Length")!)! > fileData.count)
         XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
         try? FileManager.default.removeItem(at: tempFileURL)
     }


### PR DESCRIPTION
## Description

Partially addresses https://github.com/ionic-team/capacitor-file-transfer/issues/10

The upload delegate was receiving -1 for `totalBytesExpectedToSend`. According to the [apple docs](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/urlsession(_:task:didsendbodydata:totalbytessent:totalbytesexpectedtosend:)?changes=_3) , there's a few ways in which we can do this, opted going with adding the "Content-Length" header - which was done in the [old cordova plugin](https://github.com/OutSystems/cordova-plugin-file-transfer/blob/Outsystems/src/ios/CDVFileTransfer.m#L225).

Furthermore, I noticed this error in logs in XCode when `chunkedMode` is true:

```
The request of a upload task should not contain a body or a body stream,
use upload(for:fromFile:), upload(for:from:),
or supply the body stream through the urlSession(_:needNewBodyStreamForTask:) delegate method.
```

Which I also fixed in this PR by providing the input stream via the upload delegate instead of directly in the request object.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

You may generate a xcframework using the `scripts/build_framework.sh` and test in the Capacitor Example app - https://github.com/ionic-team/capacitor-file-transfer

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
